### PR TITLE
Use arc-swap for swapping the pointer + other little things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Update dependencies
+* Make the structures Clone and provide Default implementation for the drain
+* Delegate the `Drain::is_enabled`
+* Remove the `AtomicSwitch::new_from_arc` (leaking internal details)
+
 ## 2.0.0 - 2017-04-29
 
 * Update dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-atomic"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Atomic run-time controllable drain for slog-rs"
 keywords = ["slog", "logging", "log",  "atomic"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 path = "lib.rs"
 
 [dependencies]
+arc-swap = "~0.4"
 slog = "2"
-crossbeam = "0.2.9"
 
 [dev-dependencies]
 lazy_static = "0.2.4"

--- a/lib.rs
+++ b/lib.rs
@@ -18,12 +18,18 @@ use slog::*;
 type Inner<O, E> = Arc<ArcSwap<Box<dyn SendSyncRefUnwindSafeDrain<Ok=O,Err=E>>>>;
 
 /// Handle to `AtomicSwitch` that controls it.
+#[derive(Clone)]
 pub struct AtomicSwitchCtrl<O=(), E=slog::Never>(Inner<O, E>);
 
-/// Drain wrapping another drain, allowing atomic substitution in runtime
+/// Drain wrapping another drain, allowing atomic substitution in runtime.
+#[derive(Clone)]
 pub struct AtomicSwitch<O=(), E=slog::Never>(Inner<O, E>);
 
-// TODO: Default?
+impl Default for AtomicSwitch<(), slog::Never> {
+    fn default() -> Self {
+        Self::new(Discard)
+    }
+}
 
 impl<O, E> AtomicSwitch<O, E> {
     /// Wrap `drain` in `AtomicSwitch` to allow swapping it later

--- a/lib.rs
+++ b/lib.rs
@@ -7,31 +7,32 @@
 //! See [`signal.rs` example](https://github.com/slog-rs/atomic/blob/master/examples/signal.rs).
 #![warn(missing_docs)]
 
+extern crate arc_swap;
 extern crate slog;
-extern crate crossbeam;
 
-use slog::*;
 use std::sync::Arc;
-use crossbeam::sync::ArcCell;
+
+use arc_swap::ArcSwap;
+use slog::*;
 
 /// Handle to `AtomicSwitch` that controls it.
-pub struct AtomicSwitchCtrl<O=(), E=slog::Never>(Arc<ArcCell<Box<SendSyncRefUnwindSafeDrain<Ok=O,Err=E>>>>);
+pub struct AtomicSwitchCtrl<O=(), E=slog::Never>(Arc<ArcSwap<Box<SendSyncRefUnwindSafeDrain<Ok=O,Err=E>>>>);
 
 /// Drain wrapping another drain, allowing atomic substitution in runtime
-pub struct AtomicSwitch<O=(), E=slog::Never>(Arc<ArcCell<Box<SendSyncRefUnwindSafeDrain<Ok=O,Err=E>>>>);
+pub struct AtomicSwitch<O=(), E=slog::Never>(Arc<ArcSwap<Box<SendSyncRefUnwindSafeDrain<Ok=O,Err=E>>>>);
 
 impl<O, E> AtomicSwitch<O, E> {
     /// Wrap `drain` in `AtomicSwitch` to allow swapping it later
     ///
     /// Use `AtomicSwitch::ctrl()` to get a handle to it
     pub fn new<D: SendSyncRefUnwindSafeDrain<Ok = O, Err = E> + 'static>(drain: D) -> Self {
-        AtomicSwitch::new_from_arc(Arc::new(ArcCell::new(Arc::new(Box::new(drain) as Box<SendSyncRefUnwindSafeDrain<Ok=O,Err=E>>))))
+        AtomicSwitch::new_from_arc(Arc::new(ArcSwap::from_pointee(Box::new(drain) as Box<SendSyncRefUnwindSafeDrain<Ok=O,Err=E>>)))
     }
 
     /// Create new `AtomicSwitch` from an existing `Arc<...>`
     ///
     /// See `AtomicSwitch::new()`
-    pub fn new_from_arc(d: Arc<ArcCell<Box<SendSyncRefUnwindSafeDrain<Ok = O, Err = E>>>>) -> Self {
+    pub fn new_from_arc(d: Arc<ArcSwap<Box<SendSyncRefUnwindSafeDrain<Ok = O, Err = E>>>>) -> Self {
         AtomicSwitch(d)
     }
 
@@ -44,19 +45,19 @@ impl<O, E> AtomicSwitch<O, E> {
 impl<O, E> AtomicSwitchCtrl<O, E> {
     /// Get Arc to the currently wrapped drain
     pub fn get(&self) -> Arc<Box<SendSyncRefUnwindSafeDrain<Ok = O, Err = E>>> {
-        self.0.get()
+        self.0.load_full()
     }
 
     /// Set the current wrapped drain
-    pub fn set<D: SendSyncRefUnwindSafeDrain<Ok = O, Err = E>>(&self, drain: D) {
-        let _ = self.0.set(Arc::new(Box::new(drain)));
+    pub fn set<D: SendSyncRefUnwindSafeDrain<Ok = O, Err = E> + 'static>(&self, drain: D) {
+        self.0.store(Arc::new(Box::new(drain)));
     }
 
     /// Swap the existing drain with a new one
     pub fn swap(&self,
                 drain: Arc<Box<SendSyncRefUnwindSafeDrain<Ok = O, Err = E>>>)
                 -> Arc<Box<SendSyncRefUnwindSafeDrain<Ok = O, Err = E>>> {
-        self.0.set(drain)
+        self.0.swap(drain)
     }
 
     /// Get a `AtomicSwitch` drain controlled by this `AtomicSwitchCtrl`
@@ -69,6 +70,6 @@ impl<O, E> Drain for AtomicSwitch<O, E> {
     type Ok = O;
     type Err = E;
     fn log(&self, info: &Record, kv: &OwnedKVList) -> std::result::Result<O, E> {
-        self.0.get().log(info, kv)
+        self.0.load().log(info, kv)
     }
 }

--- a/lib.rs
+++ b/lib.rs
@@ -83,4 +83,8 @@ impl<O, E> Drain for AtomicSwitch<O, E> {
     fn log(&self, info: &Record, kv: &OwnedKVList) -> std::result::Result<O, E> {
         self.0.load().log(info, kv)
     }
+
+    fn is_enabled(&self, level: Level) -> bool {
+        self.0.load().is_enabled(level)
+    }
 }

--- a/lib.rs
+++ b/lib.rs
@@ -36,15 +36,8 @@ impl<O, E> AtomicSwitch<O, E> {
     ///
     /// Use `AtomicSwitch::ctrl()` to get a handle to it
     pub fn new<D: SendSyncRefUnwindSafeDrain<Ok = O, Err = E> + 'static>(drain: D) -> Self {
-        AtomicSwitch::new_from_arc(Arc::new(ArcSwap::from_pointee(Box::new(drain))))
-    }
+        AtomicSwitch(Arc::new(ArcSwap::from_pointee(Box::new(drain))))
 
-    // TODO: This one seems a bit fishy
-    /// Create new `AtomicSwitch` from an existing `Arc<...>`
-    ///
-    /// See `AtomicSwitch::new()`
-    pub fn new_from_arc(d: Arc<ArcSwap<Box<dyn SendSyncRefUnwindSafeDrain<Ok = O, Err = E>>>>) -> Self {
-        AtomicSwitch(d)
     }
 
     /// Get a `AtomicSwitchCtrl` handle to control this `AtomicSwitch` drain


### PR DESCRIPTION
I originally wanted to do only https://github.com/slog-rs/slog/issues/222, but when I had the code opened, I added few more changes (hopefully improvements). These are each in separate commit, so if something of that is deemed unwanted, I can just drop them from the branch.

I have one further question, about the `new_from_arc` method. It leaks details about the internal implementation, which seems a bit wrong. I guess the original intention was to be able to create several interchangeable drains ‒ but after adding the `Clone` trait, it can be done in a more convenient way. Would it be OK to drop this method? It already causes a breaking change due to the change to arc-swap, so dropping it now would prevent a future breaking change on eg. arc-swap upgrade.