### PR TITLE
Update arc-swap to v1.1 to fix RUSTSEC-2020-0091

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 path = "lib.rs"
 
 [dependencies]
-arc-swap = "1.0"
+arc-swap = "1.1"
 slog = "2"
 
 [dev-dependencies]


### PR DESCRIPTION
See https://rustsec.org/advisories/RUSTSEC-2020-0091

and https://github.com/slog-rs/scope/pull/12#discussion_r546759400